### PR TITLE
Ensure event handlers are destroyed on unmount.

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -224,6 +224,12 @@ module.exports = React.createClass({
 		onStop: React.PropTypes.func
 	},
 
+	componentWillUnmount: function() {
+		// Remove any leftover event handlers
+		removeEvent(window, 'mousemove', this.handleMouseMove);
+		removeEvent(window, 'mouseup', this.handleMouseUp);
+	},
+
 	getDefaultProps: function () {
 		return {
 			axis: 'both',


### PR DESCRIPTION
These can be left over if, for instance, the draggable item has a 'close' button which
closes on mousedown.
