### PR TITLE
Duplicate condition removed

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -38,8 +38,6 @@ function matchesSelector(el, selector) {
 		return el.msMatchesSelector(selector);
 	} else if (isFunction(el.oMatchesSelector)) {
 		return el.oMatchesSelector(selector);
-	} else if (isFunction(el.webkitMatchesSelector)) {
-		return el.webkitMatchesSelector(selector);
 	}
 }
 


### PR DESCRIPTION
Duplicate condition `if (isFunction(el.webkitMatchesSelector))` is removed.
