### PR TITLE
Add option to restrict drag to bounding box

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -125,6 +125,13 @@ module.exports = React.createClass({
 		axis: React.PropTypes.oneOf(['both', 'x', 'y']),
 
 		/**
+		 * `bound` determines whether to bound the movement to the parent box.
+		 *
+		 * Defaults to false.
+		 */
+		bound: React.PropTypes.bool,
+
+		/**
 		 * `handle` specifies a selector to be used as the handle that initiates drag.
 		 *
 		 * Example:
@@ -301,6 +308,7 @@ module.exports = React.createClass({
 	getDefaultProps: function () {
 		return {
 			axis: 'both',
+			bound: false,
 			handle: null,
 			cancel: null,
 			grid: null,
@@ -405,6 +413,22 @@ module.exports = React.createClass({
 			clientY = Math.abs(clientY - this.state.clientY) >= this.props.grid[1]
 					? clientY
 					: this.state.clientY;
+		}
+
+		// Bound movement to parent box
+		var parentNode;
+		if (this.props.bound) {
+			if (clientX < 0) clientX = 0;
+			if (clientY < 0) clientY = 0;
+			if (clientX > 0 || clientY > 0) {
+				parentNode = this.getDOMNode().parentNode;
+				if (clientX > parentNode.clientWidth) {
+					clientX = parentNode.clientWidth;
+				}
+				if (clientY > parentNode.clientHeight) {
+					clientY = parentNode.clientHeight;
+				}
+			}
 		}
 
 		// Update top and left

--- a/specs/draggable.spec.js
+++ b/specs/draggable.spec.js
@@ -9,6 +9,7 @@ describe('react-draggable', function () {
 			var drag = TestUtils.renderIntoDocument(<Draggable><div/></Draggable>);
 
 			expect(drag.props.axis).toEqual('both');
+			expect(drag.props.bound).toEqual(false);
 			expect(drag.props.handle).toEqual(null);
 			expect(drag.props.cancel).toEqual(null);
 			expect(isNaN(drag.props.zIndex)).toEqual(true);
@@ -25,6 +26,7 @@ describe('react-draggable', function () {
 			var drag = TestUtils.renderIntoDocument(
 				<Draggable
 					axis="y"
+					bound={false}
 					handle=".handle"
 					cancel=".cancel"
 					grid={[10, 10]}
@@ -40,6 +42,7 @@ describe('react-draggable', function () {
 			);
 
 			expect(drag.props.axis).toEqual('y');
+			expect(drag.props.bound).toEqual(false);
 			expect(drag.props.handle).toEqual('.handle');
 			expect(drag.props.cancel).toEqual('.cancel');
 			expect(drag.props.grid).toEqual([10, 10]);


### PR DESCRIPTION
Implements #23 with rudimentary tests. Not quite sure how to test the bounding box without dragging the thing in a browser...
