### PR TITLE
Update dependencies and use `devDependencies` for `react`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   },
   "homepage": "https://github.com/mzabriskie/react-draggable",
   "dependencies": {
-    "react": "^0.11.1"
+    "react": "^0.12.0"
   },
   "devDependencies": {
-    "jsx-loader": "^0.11.0",
-    "karma": "^0.12.19",
+    "jsx-loader": "^0.12.1",
+    "karma": "^0.12.24",
     "karma-cli": "0.0.4",
-    "karma-jasmine": "^0.1.5",
-    "karma-chrome-launcher": "^0.1.4",
+    "karma-jasmine": "^0.2.3",
+    "karma-chrome-launcher": "^0.1.5",
     "karma-firefox-launcher": "^0.1.3",
-    "webpack": "^1.3.2-beta8",
-    "webpack-dev-server": "^1.4.7",
-    "karma-webpack": "^1.2.1",
+    "webpack": "^1.4.13",
+    "webpack-dev-server": "^1.6.5",
+    "karma-webpack": "^1.3.1",
     "uglify-js": "^2.4.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "url": "https://github.com/mzabriskie/react-draggable/issues"
   },
   "homepage": "https://github.com/mzabriskie/react-draggable",
-  "peerDependencies": {
-    "react": "^0.12.1"
-  },
   "devDependencies": {
     "jsx-loader": "^0.12.2",
     "karma": "^0.12.25",
@@ -38,6 +35,7 @@
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.3.1",
     "karma-webpack": "^1.3.1",
+    "react": "^0.12.1",
     "uglify-js": "^2.4.15",
     "webpack": "^1.4.13",
     "webpack-dev-server": "^1.6.6"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/mzabriskie/react-draggable/issues"
   },
   "homepage": "https://github.com/mzabriskie/react-draggable",
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.12.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   },
   "homepage": "https://github.com/mzabriskie/react-draggable",
   "peerDependencies": {
-    "react": "^0.12.0"
+    "react": "^0.12.1"
   },
   "devDependencies": {
-    "jsx-loader": "^0.12.1",
-    "karma": "^0.12.24",
-    "karma-cli": "0.0.4",
-    "karma-jasmine": "^0.2.3",
+    "jsx-loader": "^0.12.2",
+    "karma": "^0.12.25",
     "karma-chrome-launcher": "^0.1.5",
+    "karma-cli": "^0.0.4",
     "karma-firefox-launcher": "^0.1.3",
-    "webpack": "^1.4.13",
-    "webpack-dev-server": "^1.6.5",
+    "karma-jasmine": "^0.3.1",
     "karma-webpack": "^1.3.1",
-    "uglify-js": "^2.4.15"
+    "uglify-js": "^2.4.15",
+    "webpack": "^1.4.13",
+    "webpack-dev-server": "^1.6.6"
   }
 }


### PR DESCRIPTION
- Update dependencies.
- Use `devDependencies` instead of `dependencies` to prevent `react-draggable` from including its own version of React when used with packagers.

Tests pass.

See also #21 for a smaller update.
