### PR TITLE
fix: prevent process.env access from crashing browser builds

### DIFF
--- a/lib/utils/log.ts
+++ b/lib/utils/log.ts
@@ -1,4 +1,6 @@
 /*eslint no-console:0*/
 export default function log(...args: unknown[]): void {
-  if (process.env.DRAGGABLE_DEBUG) console.log(...args);
+  if (typeof process !== "undefined" && process.env?.DRAGGABLE_DEBUG) {
+    console.log(...args);
+  }
 }


### PR DESCRIPTION
## Summary

This PR prevents runtime errors in browser environments by safely checking for the existence of `process` before accessing `process.env.DRAGGABLE_DEBUG`.

## Problem

The current implementation directly accesses `process.env.DRAGGABLE_DEBUG`:

```ts
if (process.env.DRAGGABLE_DEBUG) console.log(...args);
```

In browser environments where `process` is not defined (e.g., Vite without a process polyfill), this can lead to runtime errors and affect components that depend on `react-draggable`.

## Solution

Added a guard to ensure `process` exists before accessing `process.env`:

```ts
if (typeof process !== "undefined" && process.env?.DRAGGABLE_DEBUG) {
  console.log(...args);
}
```

This preserves the existing debug logging behavior while preventing errors in environments where `process` is unavailable.

## Testing

* Verified the issue in a React + Vite application.
* Confirmed that the runtime error no longer occurs.
* Confirmed that drag functionality works correctly after the change.
* Verified that debug logging behavior remains unchanged when `DRAGGABLE_DEBUG` is enabled.
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/961171c9-329e-4724-800b-b6dd3082a7e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility in environments without a `process` object.
  * Debug logging now appears only when explicitly enabled through the debug setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->